### PR TITLE
fix mp4 type error

### DIFF
--- a/vid2vid.py
+++ b/vid2vid.py
@@ -136,7 +136,7 @@ fps = int(input_video.get(cv2.CAP_PROP_FPS))
 total_frames = int(input_video.get(cv2.CAP_PROP_FRAME_COUNT))
 
 # Create an output video file with the same fps, width, and height as the input video
-output_video = cv2.VideoWriter(OUTPUT_VIDEO, cv2.VideoWriter_fourcc(*'MP4V'), fps, (w, h))
+output_video = cv2.VideoWriter(OUTPUT_VIDEO, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
 
 prev_frame = None
 prev_frame_styled = None


### PR DESCRIPTION
MP4V to mp4v, fixes the 
"OpenCV: FFMPEG: tag 0x5634504d/'MP4V' is not supported with codec id 12 and format 'mp4 / MP4 (MPEG-4 Part 14)' OpenCV: FFMPEG: fallback to use tag 0x7634706d/'mp4v'" error that ive been having. (which was only a warning... but clean is clean