### PR TITLE
Fix Typo in Utils.py

### DIFF
--- a/scripts/base_ui.py
+++ b/scripts/base_ui.py
@@ -101,10 +101,10 @@ def inputs_ui():
                 t2v_length = gr.Slider(label='Length (in frames)', minimum=10, maximum=2048, step=10, value=40, interactive=True)
                 t2v_fps = gr.Slider(label='Video FPS', minimum=4, maximum=64, step=4, value=12, interactive=True)
              with FormRow(elem_id="txt2vid_override_settings_row") as row:
-                v2v_override_settings = create_override_settings_dropdown("txt2vid", row)
+                t2v_override_settings = create_override_settings_dropdown("txt2vid", row)
 
             with FormGroup(elem_id=f"script_container"):
-                v2v_custom_inputs = scripts.scripts_txt2img.setup_ui()
+                t2v_custom_inputs = scripts.scripts_txt2img.setup_ui()
     
     tab_vid2vid.select(fn=lambda: 'vid2vid', inputs=[], outputs=[sdcn_process_mode])
     tab_txt2vid.select(fn=lambda: 'txt2vid', inputs=[], outputs=[sdcn_process_mode])

--- a/scripts/base_ui.py
+++ b/scripts/base_ui.py
@@ -100,7 +100,11 @@ def inputs_ui():
             with gr.Row():
                 t2v_length = gr.Slider(label='Length (in frames)', minimum=10, maximum=2048, step=10, value=40, interactive=True)
                 t2v_fps = gr.Slider(label='Video FPS', minimum=4, maximum=64, step=4, value=12, interactive=True)
-        
+             with FormRow(elem_id="txt2vid_override_settings_row") as row:
+                v2v_override_settings = create_override_settings_dropdown("txt2vid", row)
+
+            with FormGroup(elem_id=f"script_container"):
+                v2v_custom_inputs = scripts.scripts_txt2img.setup_ui()
     
     tab_vid2vid.select(fn=lambda: 'vid2vid', inputs=[], outputs=[sdcn_process_mode])
     tab_txt2vid.select(fn=lambda: 'txt2vid', inputs=[], outputs=[sdcn_process_mode])

--- a/scripts/core/utils.py
+++ b/scripts/core/utils.py
@@ -7,7 +7,7 @@ def get_component_names():
     'v2v_file', 'v2v_width', 'v2v_height', 'v2v_prompt', 'v2v_n_prompt', 'v2v_cfg_scale', 'v2v_seed', 'v2v_processing_strength', 'v2v_fix_frame_strength', 
     'v2v_sampler_index', 'v2v_steps', 'v2v_override_settings',
     't2v_width', 't2v_height', 't2v_prompt', 't2v_n_prompt', 't2v_cfg_scale', 't2v_seed', 't2v_processing_strength', 't2v_fix_frame_strength',
-    'v2v_sampler_index', 'v2v_steps', 't2v_length', 't2v_fps'
+    't2v_sampler_index', 't2v_steps', 't2v_length', 't2v_fps'
   ]
 
   return components_list

--- a/scripts/core/utils.py
+++ b/scripts/core/utils.py
@@ -85,7 +85,7 @@ def args_to_dict(*args): # converts list of argumets into dictionary for better 
     't2v_inpainting_mask_invert': False,
 
     't2v_override_settings': [],
-    't2v_script_inputs': [0],
+    #'t2v_script_inputs': [0],
 
     't2v_fps': 12,
   }
@@ -99,6 +99,7 @@ def args_to_dict(*args): # converts list of argumets into dictionary for better 
           args_dict[args_list[i]] = args[i]
 
   args_dict['v2v_script_inputs'] = args[len(args_list):]
+  args_dict['t2v_script_inputs'] = args[len(args_list):] #do it for both
   return args_dict
 
 def get_mode_args(mode, args_dict):
@@ -282,7 +283,7 @@ def img2img(args_dict):
         override_settings=override_settings,
     )
 
-    p.scripts = modules.scripts.scripts_txt2img
+    p.scripts = modules.scripts.scripts_img2img
     p.script_args = args.script_inputs
 
     #if shared.cmd_opts.enable_console_prompts:


### PR DESCRIPTION
Should Fully Solve #86
There was a typo in the component list which meant that t2v steps and samplers would always remain at their default values. And we were passing an empty script input array, when there are in fact txt2vid scripts, thereby causing tons of errors by not at least having the script values being populated.